### PR TITLE
Fix for dual event issue

### DIFF
--- a/HwReader/HwReader.py
+++ b/HwReader/HwReader.py
@@ -73,11 +73,14 @@ station = inputConfig.station
 # creates appropriate input instances from config file
 aInput, eInput, bInput, sInput = InputConfig.collectInputs(inputConfig)
 
-# Creates input and key-press queues with debth: 1 (item) each.
-# event Queue is infinite for now
-inputQueue = Queue(1)
+# Creates input queue with debth: 2 (items).
+#  This is to allow up to two events to be placed in the queue
+#  from the same source.
+# Creates key-press queue with debth: 1 (item).
+# event Queue is un-used for now
+inputQueue = Queue(2)
 keyQueue = Queue(1)
-eventQueue = Queue(0)
+eventQueue =  None # Queue(0)
 
 # Creates threads
 inputThread = InputPoller(aInput, eInput, bInput, sInput, cycleTime, inputQueue)

--- a/HwReader/config.yml
+++ b/HwReader/config.yml
@@ -55,11 +55,10 @@ TestInput1:
   step: 10
 
 TestInput2:
-  event: TARGET_NEXT_ENEMY
-  event2: TARGET_PREVIOUS_ENEMY
+  event: SET_THROTTLE
   type: encoder
-  clk: 21
-  dt: 20
+  clk: 17
+  dt: 24
   step: 1 # optional
 
 ButtonTest:

--- a/HwReader/inputPoller.py
+++ b/HwReader/inputPoller.py
@@ -102,7 +102,7 @@ class InputPoller(threading.Thread):
                     if changed == True:
                         try:
                             inputQueue.put_nowait([name, counter[i]])
-                        except:
+                        except Full:
                             try:
                                 inputQueue.get_nowait()
                             except Empty:

--- a/HwReader/inputPoller.py
+++ b/HwReader/inputPoller.py
@@ -90,18 +90,24 @@ class InputPoller(threading.Thread):
 
                 # ENCODER is read
                 #
-                # If a new value is received, purges the
-                # queue and adds a new entry to it.
-                # The operation is non-blocking.
+                # When a new value is received, 
+                # Poller tries to put the input in queue (non-blocking).
+                # If the queue is full, the oldes input will be removed
+                # Finally the input is placed in the queue.
+                # To ensure the delivery of the second attempt the 
+                # operaion is blocking.
                 #
                 for i in encoder_range:
                     counter[i], changed, name = encoderInput[i].increment(counter[i])
                     if changed == True:
                         try:
-                            inputQueue.get_nowait()
-                        except Empty:
-                            pass
-                        inputQueue.put([name, counter[i]])
+                            inputQueue.put_nowait([name, counter[i]])
+                        except:
+                            try:
+                                inputQueue.get_nowait()
+                            except Empty:
+                                pass
+                            inputQueue.put([name, counter[i]])
 
                 # BUTTON is read
                 #


### PR DESCRIPTION
- Input queue size increased to two.
  - Now up to two simultanious input events can be placed in the queue
- Encoder input no longer clears the queue by default. Only if the
  queue is full.