### PR TITLE
Changed yaml Loader to BaseLoader

### DIFF
--- a/HwReader/inputConfig.py
+++ b/HwReader/inputConfig.py
@@ -68,7 +68,7 @@ class InputConfig():
             self.logger.critical("Error: Could not find %s" % filename)
             exit()
 
-        settings = yaml.load(configfile)
+        settings = yaml.load(configfile, Loader=yaml.BaseLoader)
         configfile.close()
 
         return settings


### PR DESCRIPTION
Fixes #15 
This will plug a security hole and stop the warning messages.
BaseLoader supports only simple constructions like lists and dicts.